### PR TITLE
Fix: issues parsing short syntax nested functions

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -49,7 +49,13 @@ Resources:
     Type: 'AWS::EC2::Subnet'
     Properties:
       AvailabilityZone: !Select [!Ref AZIndex, !GetAZs '']
-      CidrBlock: !Select [!Ref SubnetIndex, !Cidr [{'Fn::ImportValue': !Sub '${VpcPlainModule}-CidrBlock'}, !Ref SubnetCount, 12]]
+      CidrBlock: !Select
+        - Ref: SubnetIndex
+        - Fn::Cidr: 
+          - Fn::ImportValue: 
+              !Sub '${VpcPlainModule}-CidrBlock' 
+          - Ref: SubnetCount
+          - 12
       VpcId:
         'Fn::ImportValue': !Sub '${VpcPlainModule}-Id'
       Tags:


### PR DESCRIPTION
fix cfn-modules/vpc-subnet#1
I was getting errors on deployment as is.  I wrote this out in a longer syntax version and tested it as working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
